### PR TITLE
Sharing changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
           go get .
           go build .
 
-      - name: Upload
-        uses: actions/upload-artifact@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: stmp-linux-amd64
-          path: stmp
+          files: stmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build binaries
+
+on:
+    push:
+        paths-ignore:
+        - 'README.md'
+        - 'CHANGELOG.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up build environment
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.15
+
+      - name: Library dependencies
+        run: sudo apt-get install libmpv-dev libglx-dev libgl-dev
+
+      - name: Compile
+        run: |
+          go get .
+          go build .
+
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: stmp-linux-amd64
+          path: stmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 todo.txt
+stmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-stmp.toml
-stmp
+todo.txt

--- a/README.md
+++ b/README.md
@@ -58,3 +58,6 @@ host = 'https://your-subsonic-host.tld'
 * a - add album or song to queue
 * p - play/pause
 * -/= volume down/volume up
+* / - Search artists
+* n - Continue search forward
+* N - Continue search backwards

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ host = 'https://your-subsonic-host.tld'
 
 * 1 - folder view
 * 2 - queue view
+* 3 - playlist view
+* 4 - log (errors, etc) view
 * enter - play song (clears current queue)
 * d/delete - remove currently selected song from the queue
 * D - remove all songs from queue

--- a/api.go
+++ b/api.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 // used for generating salt
@@ -17,6 +18,7 @@ type SubsonicConnection struct {
 	Username       string
 	Password       string
 	Host           string
+	Logger         Logger
 	directoryCache map[string]SubsonicResponse
 }
 
@@ -93,7 +95,7 @@ type SubsonicPlaylists struct {
 }
 
 type SubsonicPlaylist struct {
-	Id        int              `json:"id"`
+	Id        string           `json:"id"`
 	Name      string           `json:"name"`
 	SongCount int              `json:"songCount"`
 	Entries   []SubsonicEntity `json:"entry"`
@@ -117,59 +119,13 @@ type responseWrapper struct {
 func (connection *SubsonicConnection) GetServerInfo() (*SubsonicResponse, error) {
 	query := defaultQuery(connection)
 	requestUrl := connection.Host + "/rest/ping" + "?" + query.Encode()
-	res, err := http.Get(requestUrl)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
-
-	responseBody, readErr := ioutil.ReadAll(res.Body)
-
-	if readErr != nil {
-		return nil, err
-	}
-
-	var decodedBody responseWrapper
-	err = json.Unmarshal(responseBody, &decodedBody)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &decodedBody.Response, nil
+	return connection.getResponse("GetServerInfo", requestUrl)
 }
 
 func (connection *SubsonicConnection) GetIndexes() (*SubsonicResponse, error) {
 	query := defaultQuery(connection)
 	requestUrl := connection.Host + "/rest/getIndexes" + "?" + query.Encode()
-	res, err := http.Get(requestUrl)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
-
-	responseBody, readErr := ioutil.ReadAll(res.Body)
-
-	if readErr != nil {
-		return nil, err
-	}
-
-	var decodedBody responseWrapper
-	err = json.Unmarshal(responseBody, &decodedBody)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &decodedBody.Response, nil
+	return connection.getResponse("GetIndexes", requestUrl)
 }
 
 func (connection *SubsonicConnection) GetMusicDirectory(id string) (*SubsonicResponse, error) {
@@ -180,64 +136,44 @@ func (connection *SubsonicConnection) GetMusicDirectory(id string) (*SubsonicRes
 	query := defaultQuery(connection)
 	query.Set("id", id)
 	requestUrl := connection.Host + "/rest/getMusicDirectory" + "?" + query.Encode()
-	res, err := http.Get(requestUrl)
-
+	resp, err := connection.getResponse("GetMusicDirectory", requestUrl)
 	if err != nil {
-		return nil, err
-	}
-
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
-
-	responseBody, readErr := ioutil.ReadAll(res.Body)
-
-	if readErr != nil {
-		return nil, err
-	}
-
-	var decodedBody responseWrapper
-	err = json.Unmarshal(responseBody, &decodedBody)
-
-	if err != nil {
-		return nil, err
+		return resp, err
 	}
 
 	// on a sucessful request, cache the response
-	if decodedBody.Response.Status == "ok" {
-		connection.directoryCache[id] = decodedBody.Response
+	if resp.Status == "ok" {
+		connection.directoryCache[id] = *resp
 	}
 
-	return &decodedBody.Response, nil
+	return resp, nil
 }
 
 func (connection *SubsonicConnection) GetPlaylists() (*SubsonicResponse, error) {
 	query := defaultQuery(connection)
 	requestUrl := connection.Host + "/rest/getPlaylists" + "?" + query.Encode()
-	res, err := http.Get(requestUrl)
-
+	resp, err := connection.getResponse("GetPlaylists", requestUrl)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 
-	if res.Body != nil {
-		defer res.Body.Close()
+	for i := 0; i < len(resp.Playlists.Playlists); i++ {
+		playlist := &resp.Playlists.Playlists[i]
+
+		if playlist.SongCount == 0 {
+			continue
+		}
+
+		response, err := connection.GetPlaylist(playlist.Id)
+
+		if err != nil {
+			return nil, err
+		}
+
+		playlist.Entries = response.Playlist.Entries
 	}
 
-	responseBody, readErr := ioutil.ReadAll(res.Body)
-
-	if readErr != nil {
-		return nil, err
-	}
-
-	var decodedBody responseWrapper
-	err = json.Unmarshal(responseBody, &decodedBody)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &decodedBody.Response, nil
+	return resp, nil
 }
 
 func (connection *SubsonicConnection) GetPlaylist(id string) (*SubsonicResponse, error) {
@@ -245,37 +181,18 @@ func (connection *SubsonicConnection) GetPlaylist(id string) (*SubsonicResponse,
 	query.Set("id", id)
 
 	requestUrl := connection.Host + "/rest/getPlaylist" + "?" + query.Encode()
-	res, err := http.Get(requestUrl)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
-
-	responseBody, readErr := ioutil.ReadAll(res.Body)
-
-	if readErr != nil {
-		return nil, err
-	}
-
-	var decodedBody responseWrapper
-	err = json.Unmarshal(responseBody, &decodedBody)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &decodedBody.Response, nil
+	return connection.getResponse("GetPlaylist", requestUrl)
 }
 
 func (connection *SubsonicConnection) CreatePlaylist(name string) (*SubsonicResponse, error) {
 	query := defaultQuery(connection)
 	query.Set("name", name)
-
 	requestUrl := connection.Host + "/rest/createPlaylist" + "?" + query.Encode()
+	return connection.getResponse("GetPlaylist", requestUrl)
+}
+
+func (connection *SubsonicConnection) getResponse(caller, requestUrl string) (*SubsonicResponse, error) {
+	connection.Logger.Printf("%s %s", caller, requestUrl)
 	res, err := http.Get(requestUrl)
 
 	if err != nil {
@@ -305,45 +222,30 @@ func (connection *SubsonicConnection) CreatePlaylist(name string) (*SubsonicResp
 func (connection *SubsonicConnection) DeletePlaylist(id string) error {
 	query := defaultQuery(connection)
 	query.Set("id", id)
-
 	requestUrl := connection.Host + "/rest/deletePlaylist" + "?" + query.Encode()
+	connection.Logger.Printf("DeletePlaylist %s", requestUrl)
 	_, err := http.Get(requestUrl)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (connection *SubsonicConnection) AddSongToPlaylist(playlistId string, songId string) error {
 	query := defaultQuery(connection)
 	query.Set("playlistId", playlistId)
 	query.Set("songIdToAdd", songId)
-
 	requestUrl := connection.Host + "/rest/updatePlaylist" + "?" + query.Encode()
+	connection.Logger.Printf("AddSongToPlaylist %s", requestUrl)
 	_, err := http.Get(requestUrl)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (connection *SubsonicConnection) RemoveSongFromPlaylist(playlistId string, songIndex int) error {
 	query := defaultQuery(connection)
 	query.Set("playlistId", playlistId)
-	query.Set("songIndexToRemove", string(songIndex))
-
+	query.Set("songIndexToRemove", strconv.Itoa(songIndex))
 	requestUrl := connection.Host + "/rest/updatePlaylist" + "?" + query.Encode()
+	connection.Logger.Printf("RemoveSongFromPlaylist %s", requestUrl)
 	_, err := http.Get(requestUrl)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // note that this function does not make a request, it just formats the play url

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/gdamore/tcell/v2 v2.1.0
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/rivo/tview v0.0.0-20201204190810-5406288b8e4e
 	github.com/spf13/viper v1.7.1
 	github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/gui.go
+++ b/gui.go
@@ -109,6 +109,9 @@ func (ui *Ui) handleDeleteFromQueue() {
 
 func (ui *Ui) handleAddEntityToQueue() {
 	currentIndex := ui.entityList.GetCurrentItem()
+	if currentIndex+1 < ui.entityList.GetItemCount() {
+		ui.entityList.SetCurrentItem(currentIndex + 1)
+	}
 
 	// if we have a parent directory subtract 1 to account for the [..]
 	// which would be index 0 in that case with index 1 being the first entity
@@ -127,12 +130,16 @@ func (ui *Ui) handleAddEntityToQueue() {
 	} else {
 		ui.addSongToQueue(&entity)
 	}
+
 	updateQueueList(ui.player, ui.queueList)
 }
 
 func (ui *Ui) handleAddPlaylistSongToQueue() {
 	playlistIndex := ui.playlistList.GetCurrentItem()
 	entityIndex := ui.selectedPlaylist.GetCurrentItem()
+	if entityIndex+1 < ui.selectedPlaylist.GetItemCount() {
+		ui.selectedPlaylist.SetCurrentItem(entityIndex + 1)
+	}
 
 	// TODO add some bounds checking here
 	if playlistIndex == -1 || entityIndex == -1 {
@@ -141,17 +148,22 @@ func (ui *Ui) handleAddPlaylistSongToQueue() {
 
 	entity := ui.playlists[playlistIndex].Entries[entityIndex]
 	ui.addSongToQueue(&entity)
+
 	updateQueueList(ui.player, ui.queueList)
 }
 
 func (ui *Ui) handleAddPlaylistToQueue() {
 	currentIndex := ui.playlistList.GetCurrentItem()
+	if currentIndex+1 < ui.playlistList.GetItemCount() {
+		ui.playlistList.SetCurrentItem(currentIndex + 1)
+	}
 
 	playlist := ui.playlists[currentIndex]
 
 	for _, entity := range playlist.Entries {
 		ui.addSongToQueue(&entity)
 	}
+
 	updateQueueList(ui.player, ui.queueList)
 }
 
@@ -186,6 +198,10 @@ func (ui *Ui) handleAddSongToPlaylist(playlist *SubsonicPlaylist) {
 	for _, playlist := range ui.playlists {
 		ui.playlistList.AddItem(playlist.Name, "", 0, nil)
 		ui.addToPlaylistList.AddItem(playlist.Name, "", 0, nil)
+	}
+
+	if currentIndex+1 < ui.entityList.GetItemCount() {
+		ui.entityList.SetCurrentItem(currentIndex + 1)
 	}
 }
 
@@ -492,9 +508,6 @@ func (ui *Ui) createQueuePage(titleFlex *tview.Flex) *tview.Flex {
 		if event.Key() == tcell.KeyDelete || event.Rune() == 'd' {
 			ui.handleDeleteFromQueue()
 			return nil
-		}
-		switch event.Rune() {
-		case 'n':
 		}
 
 		return event

--- a/gui.go
+++ b/gui.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
@@ -11,33 +10,38 @@ import (
 	"github.com/wildeyedskies/go-mpv/mpv"
 )
 
-/// struct contains all the updatable elements of the Ui
+// struct contains all the updatable elements of the Ui
 type Ui struct {
-	app              *tview.Application
-	pages            *tview.Pages
-	entityList       *tview.List
-	queueList        *tview.List
-	playlistList     *tview.List
-	selectedPlaylist *tview.List
-	newPlaylistInput *tview.InputField
-	startStopStatus  *tview.TextView
-	playerStatus     *tview.TextView
-	currentDirectory *SubsonicDirectory
-	artistIdList     []string
-	playlists        []SubsonicPlaylist
-	connection       *SubsonicConnection
-	player           *Player
+	app               *tview.Application
+	pages             *tview.Pages
+	entityList        *tview.List
+	queueList         *tview.List
+	playlistList      *tview.List
+	addToPlaylistList *tview.List
+	selectedPlaylist  *tview.List
+	newPlaylistInput  *tview.InputField
+	startStopStatus   *tview.TextView
+	currentPage       *tview.TextView
+	playerStatus      *tview.TextView
+	logList           *tview.List
+	currentDirectory  *SubsonicDirectory
+	artistIdList      []string
+	playlists         []SubsonicPlaylist
+	connection        *SubsonicConnection
+	player            *Player
 }
 
-func handleEntitySelected(directoryId string, ui *Ui) {
-	// TODO handle error here
-	response, _ := ui.connection.GetMusicDirectory(directoryId)
+func (ui *Ui) handleEntitySelected(directoryId string) {
+	response, err := ui.connection.GetMusicDirectory(directoryId)
+	if err != nil {
+		ui.logList.AddItem(fmt.Sprintf("handleEntitySelected: GetMusicDirectory %s -- %s", directoryId, err.Error()), "", 0, nil)
+	}
 
 	ui.currentDirectory = &response.Directory
 	ui.entityList.Clear()
 	if response.Directory.Parent != "" {
 		ui.entityList.AddItem(tview.Escape("[..]"), "", 0,
-			makeEntityHandler(response.Directory.Parent, ui))
+			ui.makeEntityHandler(response.Directory.Parent))
 	}
 
 	for _, entity := range response.Directory.Entities {
@@ -45,7 +49,7 @@ func handleEntitySelected(directoryId string, ui *Ui) {
 		var handler func()
 		if entity.IsDirectory {
 			title = tview.Escape("[" + entity.Title + "]")
-			handler = makeEntityHandler(entity.Id, ui)
+			handler = ui.makeEntityHandler(entity.Id)
 		} else {
 			title = entity.getSongTitle()
 			handler = makeSongHandler(ui.connection.GetPlayUrl(&entity),
@@ -57,7 +61,7 @@ func handleEntitySelected(directoryId string, ui *Ui) {
 	}
 }
 
-func handlePlaylistSelected(playlist SubsonicPlaylist, ui *Ui) {
+func (ui *Ui) handlePlaylistSelected(playlist SubsonicPlaylist) {
 	ui.selectedPlaylist.Clear()
 
 	for _, entity := range playlist.Entries {
@@ -65,14 +69,13 @@ func handlePlaylistSelected(playlist SubsonicPlaylist, ui *Ui) {
 		var handler func()
 
 		title = entity.getSongTitle()
-		handler = makeSongHandler(ui.connection.GetPlayUrl(&entity),
-			title, entity.Artist, entity.Duration, ui.player, ui.selectedPlaylist)
+		handler = makeSongHandler(ui.connection.GetPlayUrl(&entity), title, entity.Artist, entity.Duration, ui.player, ui.queueList)
 
 		ui.selectedPlaylist.AddItem(title, "", 0, handler)
 	}
 }
 
-func handleDeleteFromQueue(ui *Ui) {
+func (ui *Ui) handleDeleteFromQueue() {
 	currentIndex := ui.queueList.GetCurrentItem()
 	queue := ui.player.Queue
 
@@ -82,8 +85,13 @@ func handleDeleteFromQueue(ui *Ui) {
 
 	// if the deleted item was the first one, and the player is loaded
 	// remove the track. Removing the track auto starts the next one
-	if currentIndex == 0 && ui.player.IsSongLoaded() {
-		ui.player.Stop()
+	if currentIndex == 0 {
+		if isSongLoaded, err := ui.player.IsSongLoaded(); err != nil {
+			ui.logList.AddItem(fmt.Sprintf("handleDeleteFromQueue: IsSongLoaded -- %s", err.Error()), "", 0, nil)
+			return
+		} else if isSongLoaded {
+			ui.player.Stop()
+		}
 		return
 	}
 
@@ -91,13 +99,13 @@ func handleDeleteFromQueue(ui *Ui) {
 	if len(ui.player.Queue) > 1 {
 		ui.player.Queue = append(queue[:currentIndex], queue[currentIndex+1:]...)
 	} else {
-		ui.player.Queue = nil
+		ui.player.Queue = make([]QueueItem, 0)
 	}
 
 	updateQueueList(ui.player, ui.queueList)
 }
 
-func handleAddEntityToQueue(ui *Ui) {
+func (ui *Ui) handleAddEntityToQueue() {
 	currentIndex := ui.entityList.GetCurrentItem()
 
 	// if we have a parent directory subtract 1 to account for the [..]
@@ -113,14 +121,14 @@ func handleAddEntityToQueue(ui *Ui) {
 	entity := ui.currentDirectory.Entities[currentIndex]
 
 	if entity.IsDirectory {
-		addDirectoryToQueue(&entity, ui)
+		ui.addDirectoryToQueue(&entity)
 	} else {
-		addSongToQueue(&entity, ui)
+		ui.addSongToQueue(&entity)
 	}
 	updateQueueList(ui.player, ui.queueList)
 }
 
-func handleAddPlaylistSongToQueue(ui *Ui) {
+func (ui *Ui) handleAddPlaylistSongToQueue() {
 	playlistIndex := ui.playlistList.GetCurrentItem()
 	entityIndex := ui.selectedPlaylist.GetCurrentItem()
 
@@ -130,22 +138,22 @@ func handleAddPlaylistSongToQueue(ui *Ui) {
 	}
 
 	entity := ui.playlists[playlistIndex].Entries[entityIndex]
-	addSongToQueue(&entity, ui)
+	ui.addSongToQueue(&entity)
 	updateQueueList(ui.player, ui.queueList)
 }
 
-func handleAddPlaylistToQueue(ui *Ui) {
+func (ui *Ui) handleAddPlaylistToQueue() {
 	currentIndex := ui.playlistList.GetCurrentItem()
 
 	playlist := ui.playlists[currentIndex]
 
 	for _, entity := range playlist.Entries {
-		addSongToQueue(&entity, ui)
+		ui.addSongToQueue(&entity)
 	}
 	updateQueueList(ui.player, ui.queueList)
 }
 
-func handleAddSongToPlaylist(ui *Ui, playlist *SubsonicPlaylist) {
+func (ui *Ui) handleAddSongToPlaylist(playlist *SubsonicPlaylist) {
 	currentIndex := ui.entityList.GetCurrentItem()
 
 	// if we have a parent directory subtract 1 to account for the [..]
@@ -161,24 +169,41 @@ func handleAddSongToPlaylist(ui *Ui, playlist *SubsonicPlaylist) {
 	entity := ui.currentDirectory.Entities[currentIndex]
 
 	if !entity.IsDirectory {
-		ui.connection.AddSongToPlaylist(strconv.Itoa(playlist.Id), entity.Id)
+		ui.connection.AddSongToPlaylist(playlist.Id, entity.Id)
 	}
-	//TODO update the playlists
+	// update the playlists
+	response, err := ui.connection.GetPlaylists()
+	if err != nil {
+		ui.logList.AddItem(fmt.Sprintf("handleAddSongToPlaylist: GetPlaylists -- %s", err.Error()), "", 0, nil)
+	}
+	ui.playlists = response.Playlists.Playlists
+
+	ui.playlistList.Clear()
+	ui.addToPlaylistList.Clear()
+
+	for _, playlist := range ui.playlists {
+		ui.playlistList.AddItem(playlist.Name, "", 0, nil)
+		ui.addToPlaylistList.AddItem(playlist.Name, "", 0, nil)
+	}
 }
 
-func addDirectoryToQueue(entity *SubsonicEntity, ui *Ui) {
-	response, _ := ui.connection.GetMusicDirectory(entity.Id)
+func (ui *Ui) addDirectoryToQueue(entity *SubsonicEntity) {
+	response, err := ui.connection.GetMusicDirectory(entity.Id)
+	if err != nil {
+		ui.logList.AddItem(fmt.Sprintf("addDirectoryToQueue: GetMusicDirectory %s -- %s", entity.Id, err.Error()), "", 0, nil)
+		return
+	}
 
 	for _, e := range response.Directory.Entities {
 		if e.IsDirectory {
-			addDirectoryToQueue(&e, ui)
+			ui.addDirectoryToQueue(&e)
 		} else {
-			addSongToQueue(&e, ui)
+			ui.addSongToQueue(&e)
 		}
 	}
 }
 
-func addSongToQueue(entity *SubsonicEntity, ui *Ui) {
+func (ui *Ui) addSongToQueue(entity *SubsonicEntity) {
 	uri := ui.connection.GetPlayUrl(entity)
 
 	var artist string
@@ -197,24 +222,48 @@ func addSongToQueue(entity *SubsonicEntity, ui *Ui) {
 	ui.player.Queue = append(ui.player.Queue, queueItem)
 }
 
-func newPlaylist(name string, ui *Ui) {
-	response, _ := ui.connection.CreatePlaylist(name)
+func (ui *Ui) newPlaylist(name string) {
+	response, err := ui.connection.CreatePlaylist(name)
+	if err != nil {
+		ui.logList.AddItem(fmt.Sprintf("newPlaylist: CreatePlaylist %s -- %s", name, err.Error()), "", 0, nil)
+		return
+	}
+
+	ui.playlists = append(ui.playlists, response.Playlist)
 
 	ui.playlistList.AddItem(response.Playlist.Name, "", 0, nil)
-	ui.playlists = append(ui.playlists, response.Playlist)
+	ui.addToPlaylistList.AddItem(response.Playlist.Name, "", 0, nil)
 }
 
-func makeSongHandler(uri string, title string, artist string, duration int, player *Player,
-	queueList *tview.List) func() {
+func (ui *Ui) deletePlaylist(index int) {
+	if index == -1 || len(ui.playlists) < index {
+		return
+	}
+
+	playlist := ui.playlists[index]
+
+	if index == 0 {
+		ui.playlistList.SetCurrentItem(1)
+	}
+
+	// Removes item with specified index
+	ui.playlists = append(ui.playlists[:index], ui.playlists[index+1:]...)
+
+	ui.playlistList.RemoveItem(index)
+	ui.addToPlaylistList.RemoveItem(index)
+	ui.connection.DeletePlaylist(playlist.Id)
+}
+
+func makeSongHandler(uri string, title string, artist string, duration int, player *Player, queueList *tview.List) func() {
 	return func() {
 		player.Play(uri, title, artist, duration)
 		updateQueueList(player, queueList)
 	}
 }
 
-func makeEntityHandler(directoryId string, ui *Ui) func() {
+func (ui *Ui) makeEntityHandler(directoryId string) func() {
 	return func() {
-		handleEntitySelected(directoryId, ui)
+		ui.handleEntitySelected(directoryId)
 	}
 }
 
@@ -229,11 +278,17 @@ func createUi(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connectio
 	// list of playlists
 	playlistList := tview.NewList().ShowSecondaryText(false).
 		SetSelectedFocusOnly(true)
+	// same as 'playlistList' except for the addToPlaylistModal
+	// - we need a specific version of this because we need different keybinds
+	addToPlaylistList := tview.NewList().ShowSecondaryText(false)
 	// songs in the selected playlist
 	selectedPlaylist := tview.NewList().ShowSecondaryText(false)
 	// status text at the top
 	startStopStatus := tview.NewTextView().SetText("[::b]stmp: [red]stopped").
 		SetTextAlign(tview.AlignLeft).
+		SetDynamicColors(true)
+	currentPage := tview.NewTextView().SetText("Browser").
+		SetTextAlign(tview.AlignCenter).
 		SetDynamicColors(true)
 	playerStatus := tview.NewTextView().SetText("[::b][100%][0:00/0:00]").
 		SetTextAlign(tview.AlignRight).
@@ -241,25 +296,29 @@ func createUi(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connectio
 	newPlaylistInput := tview.NewInputField().
 		SetLabel("Playlist name:").
 		SetFieldWidth(50)
+	logs := tview.NewList().ShowSecondaryText(false)
 	player, err := InitPlayer()
 	var currentDirectory *SubsonicDirectory
 	var artistIdList []string
 
 	ui := Ui{
-		app,
-		pages,
-		entityList,
-		queueList,
-		playlistList,
-		selectedPlaylist,
-		newPlaylistInput,
-		startStopStatus,
-		playerStatus,
-		currentDirectory,
-		artistIdList,
-		*playlists,
-		connection,
-		player,
+		app:               app,
+		pages:             pages,
+		entityList:        entityList,
+		queueList:         queueList,
+		playlistList:      playlistList,
+		addToPlaylistList: addToPlaylistList,
+		selectedPlaylist:  selectedPlaylist,
+		newPlaylistInput:  newPlaylistInput,
+		startStopStatus:   startStopStatus,
+		currentPage:       currentPage,
+		playerStatus:      playerStatus,
+		logList:           logs,
+		currentDirectory:  currentDirectory,
+		artistIdList:      artistIdList,
+		playlists:         *playlists,
+		connection:        connection,
+		player:            player,
 	}
 
 	if err != nil {
@@ -267,10 +326,17 @@ func createUi(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connectio
 		fmt.Println("Unable to initialize mpv. Is mpv installed?")
 	}
 
+	go func() {
+		select {
+		case msg := <-connection.Logger.prints:
+			ui.logList.AddItem(msg, "", 0, nil)
+		}
+	}()
+
 	return &ui
 }
 
-func createBrowserPage(ui *Ui, titleFlex *tview.Flex, indexes *[]SubsonicIndex) (*tview.Flex, tview.Primitive) {
+func (ui *Ui) createBrowserPage(titleFlex *tview.Flex, indexes *[]SubsonicIndex) (*tview.Flex, tview.Primitive) {
 	// artist list, used to map the index of
 	artistList := tview.NewList().ShowSecondaryText(false)
 	for _, index := range *indexes {
@@ -298,29 +364,29 @@ func createBrowserPage(ui *Ui, titleFlex *tview.Flex, indexes *[]SubsonicIndex) 
 	})
 
 	artistList.SetChangedFunc(func(index int, _ string, _ string, _ rune) {
-		handleEntitySelected(ui.artistIdList[index], ui)
+		ui.handleEntitySelected(ui.artistIdList[index])
 	})
 
-	// we need a specific version of this because we need different keybinds
-	playlistList := tview.NewList().ShowSecondaryText(false)
 	for _, playlist := range ui.playlists {
-		playlistList.AddItem(playlist.Name, "", 0, nil)
+		ui.addToPlaylistList.AddItem(playlist.Name, "", 0, nil)
 	}
+	ui.addToPlaylistList.SetBorder(true).
+		SetTitle("Add to Playlist")
 
 	addToPlaylistFlex := tview.NewFlex().
 		SetDirection(tview.FlexRow).
-		AddItem(playlistList, 0, 1, true)
+		AddItem(ui.addToPlaylistList, 0, 1, true)
 
 	addToPlaylistModal := makeModal(addToPlaylistFlex, 60, 20)
 
-	playlistList.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+	ui.addToPlaylistList.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEscape {
 			ui.pages.HidePage("addToPlaylist")
 			ui.pages.SwitchToPage("browser")
 			ui.app.SetFocus(ui.entityList)
 		} else if event.Key() == tcell.KeyEnter {
-			playlist := ui.playlists[playlistList.GetCurrentItem()]
-			handleAddSongToPlaylist(ui, &playlist)
+			playlist := ui.playlists[ui.addToPlaylistList.GetCurrentItem()]
+			ui.handleAddSongToPlaylist(&playlist)
 
 			ui.pages.HidePage("addToPlaylist")
 			ui.pages.SwitchToPage("browser")
@@ -335,13 +401,13 @@ func createBrowserPage(ui *Ui, titleFlex *tview.Flex, indexes *[]SubsonicIndex) 
 			return nil
 		}
 		if event.Rune() == 'a' {
-			handleAddEntityToQueue(ui)
+			ui.handleAddEntityToQueue()
 			return nil
 		}
 		// only makes sense to add to a playlist if there are playlists
 		if event.Rune() == 'A' && ui.playlistList.GetItemCount() > 0 {
 			ui.pages.ShowPage("addToPlaylist")
-			ui.app.SetFocus(playlistList)
+			ui.app.SetFocus(ui.addToPlaylistList)
 			return nil
 		}
 		return event
@@ -350,14 +416,14 @@ func createBrowserPage(ui *Ui, titleFlex *tview.Flex, indexes *[]SubsonicIndex) 
 	return browserFlex, addToPlaylistModal
 }
 
-func createQueuePage(ui *Ui, titleFlex *tview.Flex) *tview.Flex {
+func (ui *Ui) createQueuePage(titleFlex *tview.Flex) *tview.Flex {
 	queueFlex := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(titleFlex, 1, 0, false).
 		AddItem(ui.queueList, 0, 1, true)
 
 	ui.queueList.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyDelete || event.Rune() == 'd' {
-			handleDeleteFromQueue(ui)
+			ui.handleDeleteFromQueue()
 			return nil
 		}
 
@@ -367,14 +433,14 @@ func createQueuePage(ui *Ui, titleFlex *tview.Flex) *tview.Flex {
 	return queueFlex
 }
 
-func createPlaylistPage(ui *Ui, titleFlex *tview.Flex) *tview.Flex {
+func (ui *Ui) createPlaylistPage(titleFlex *tview.Flex) (*tview.Flex, tview.Primitive) {
 	//add the playlists
 	for _, playlist := range ui.playlists {
 		ui.playlistList.AddItem(playlist.Name, "", 0, nil)
 	}
 
 	ui.playlistList.SetChangedFunc(func(index int, _ string, _ string, _ rune) {
-		handlePlaylistSelected(ui.playlists[index], ui)
+		ui.handlePlaylistSelected(ui.playlists[index])
 	})
 
 	playlistColFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
@@ -387,7 +453,7 @@ func createPlaylistPage(ui *Ui, titleFlex *tview.Flex) *tview.Flex {
 
 	ui.newPlaylistInput.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyEnter {
-			newPlaylist(ui.newPlaylistInput.GetText(), ui)
+			ui.newPlaylist(ui.newPlaylistInput.GetText())
 			playlistFlex.Clear()
 			playlistFlex.AddItem(titleFlex, 1, 0, false)
 			playlistFlex.AddItem(playlistColFlex, 0, 1, true)
@@ -410,12 +476,15 @@ func createPlaylistPage(ui *Ui, titleFlex *tview.Flex) *tview.Flex {
 			return nil
 		}
 		if event.Rune() == 'a' {
-			handleAddPlaylistToQueue(ui)
+			ui.handleAddPlaylistToQueue()
 			return nil
 		}
 		if event.Rune() == 'n' {
 			playlistFlex.AddItem(ui.newPlaylistInput, 0, 1, true)
 			ui.app.SetFocus(ui.newPlaylistInput)
+		}
+		if event.Rune() == 'd' {
+			ui.pages.ShowPage("deletePlaylist")
 		}
 		return event
 	})
@@ -426,13 +495,50 @@ func createPlaylistPage(ui *Ui, titleFlex *tview.Flex) *tview.Flex {
 			return nil
 		}
 		if event.Rune() == 'a' {
-			handleAddPlaylistSongToQueue(ui)
+			ui.handleAddPlaylistSongToQueue()
 			return nil
 		}
 		return event
 	})
 
-	return playlistFlex
+	deletePlaylistList := tview.NewList().
+		ShowSecondaryText(false)
+
+	deletePlaylistList.AddItem("Confirm", "", 0, nil)
+
+	deletePlaylistList.SetBorder(true).
+		SetTitle("Confirm deletion")
+
+	deletePlaylistFlex := tview.NewFlex().
+		SetDirection(tview.FlexColumn).
+		AddItem(deletePlaylistList, 0, 1, true)
+
+	deletePlaylistList.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEnter {
+			ui.deletePlaylist(ui.playlistList.GetCurrentItem())
+			ui.app.SetFocus(ui.playlistList)
+			ui.pages.HidePage("deletePlaylist")
+			return nil
+		}
+		if event.Key() == tcell.KeyEscape {
+			ui.app.SetFocus(ui.playlistList)
+			ui.pages.HidePage("deletePlaylist")
+			return nil
+		}
+		return event
+	})
+
+	deletePlaylistModal := makeModal(deletePlaylistFlex, 20, 3)
+
+	return playlistFlex, deletePlaylistModal
+}
+
+func (ui *Ui) createLogPage(titleFlex *tview.Flex) *tview.Flex {
+	logFlex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(titleFlex, 1, 0, false).
+		AddItem(ui.logList, 0, 1, true)
+
+	return logFlex
 }
 
 func InitGui(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *SubsonicConnection) *Ui {
@@ -443,19 +549,23 @@ func InitGui(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection
 	//title row flex
 	titleFlex := tview.NewFlex().SetDirection(tview.FlexColumn).
 		AddItem(ui.startStopStatus, 0, 1, false).
+		AddItem(ui.currentPage, 0, 1, false).
 		AddItem(ui.playerStatus, 0, 1, false)
 
-	browserFlex, addToPlaylistModal := createBrowserPage(ui, titleFlex, indexes)
-	queueFlex := createQueuePage(ui, titleFlex)
-	playlistFlex := createPlaylistPage(ui, titleFlex)
+	browserFlex, addToPlaylistModal := ui.createBrowserPage(titleFlex, indexes)
+	queueFlex := ui.createQueuePage(titleFlex)
+	playlistFlex, deletePlaylistModal := ui.createPlaylistPage(titleFlex)
+	logListFlex := ui.createLogPage(titleFlex)
 
 	// handle
-	go handleMpvEvents(ui)
+	go ui.handleMpvEvents()
 
 	ui.pages.AddPage("browser", browserFlex, true, true).
 		AddPage("queue", queueFlex, true, false).
 		AddPage("playlists", playlistFlex, true, false).
-		AddPage("addToPlaylist", addToPlaylistModal, true, false)
+		AddPage("addToPlaylist", addToPlaylistModal, true, false).
+		AddPage("deletePlaylist", deletePlaylistModal, true, false).
+		AddPage("log", logListFlex, true, false)
 
 	ui.pages.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		// we don't want any of these firing if we're trying to add a new playlist
@@ -463,31 +573,37 @@ func InitGui(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection
 			return event
 		}
 
-		if event.Rune() == '1' {
+		switch event.Rune() {
+		case '1':
 			ui.pages.SwitchToPage("browser")
-			return nil
-		}
-		if event.Rune() == '2' {
+			ui.currentPage.SetText("Browser")
+		case '2':
 			ui.pages.SwitchToPage("queue")
-			return nil
-		}
-		if event.Rune() == '3' {
+			ui.currentPage.SetText("Queue")
+		case '3':
 			ui.pages.SwitchToPage("playlists")
-			return nil
-		}
-		if event.Rune() == 'q' {
+			ui.currentPage.SetText("Playlists")
+		case '4':
+			ui.pages.SwitchToPage("log")
+			ui.currentPage.SetText("Log")
+		case 'q':
 			ui.player.EventChannel <- nil
 			ui.player.Instance.TerminateDestroy()
 			ui.app.Stop()
-		}
-		if event.Rune() == 'D' {
-			ui.player.Queue = nil
-			ui.player.Stop()
+		case 'D':
+			ui.player.Queue = make([]QueueItem, 0)
+			err := ui.player.Stop()
+			if err != nil {
+				ui.logList.AddItem(fmt.Sprintf("InitGui: Stop -- %s", err.Error()), "", 0, nil)
+			}
 			updateQueueList(ui.player, ui.queueList)
-		}
-
-		if event.Rune() == 'p' {
-			status := ui.player.Pause()
+		case 'p':
+			status, err := ui.player.Pause()
+			if err != nil {
+				ui.logList.AddItem(fmt.Sprintf("InitGui: Pause -- %s", err.Error()), "", 0, nil)
+				ui.startStopStatus.SetText("[::b]stmp: [red]error")
+				return nil
+			}
 			if status == PlayerStopped {
 				ui.startStopStatus.SetText("[::b]stmp: [red]stopped")
 			} else if status == PlayerPlaying {
@@ -496,15 +612,27 @@ func InitGui(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection
 				ui.startStopStatus.SetText("[::b]stmp: [yellow]paused")
 			}
 			return nil
-		}
-
-		if event.Rune() == '-' {
-			ui.player.AdjustVolume(-5)
+		case '-':
+			if err := ui.player.AdjustVolume(-5); err != nil {
+				ui.logList.AddItem(fmt.Sprintf("InitGui: AdjustVolume %d -- %s", -5, err.Error()), "", 0, nil)
+			}
 			return nil
-		}
 
-		if event.Rune() == '=' {
-			ui.player.AdjustVolume(5)
+		case '=':
+			if err := ui.player.AdjustVolume(5); err != nil {
+				ui.logList.AddItem(fmt.Sprintf("InitGui: AdjustVolume %d -- %s", 5, err.Error()), "", 0, nil)
+			}
+			return nil
+
+		case '.':
+			if err := ui.player.Seek(10); err != nil {
+				ui.logList.AddItem(fmt.Sprintf("InitGui: Seek %d -- %s", 10, err.Error()), "", 0, nil)
+			}
+			return nil
+		case ',':
+			if err := ui.player.Seek(-10); err != nil {
+				ui.logList.AddItem(fmt.Sprintf("InitGui: Seek %d -- %s", -10, err.Error()), "", 0, nil)
+			}
 			return nil
 		}
 
@@ -526,7 +654,10 @@ func updateQueueList(player *Player, queueList *tview.List) {
 	}
 }
 
-func handleMpvEvents(ui *Ui) {
+func (ui *Ui) handleMpvEvents() {
+	ui.player.Instance.ObserveProperty(0, "time-pos", mpv.FORMAT_DOUBLE)
+	ui.player.Instance.ObserveProperty(0, "duration", mpv.FORMAT_DOUBLE)
+	ui.player.Instance.ObserveProperty(0, "volume", mpv.FORMAT_INT64)
 	for {
 		e := <-ui.player.EventChannel
 		if e == nil {
@@ -539,18 +670,37 @@ func handleMpvEvents(ui *Ui) {
 				ui.player.Queue = ui.player.Queue[1:]
 			}
 			updateQueueList(ui.player, ui.queueList)
-			ui.player.PlayNextTrack()
+			err := ui.player.PlayNextTrack()
+			if err != nil {
+				ui.logList.AddItem(fmt.Sprintf("handleMoveEvents: PlayNextTrack -- %s", err.Error()), "", 0, nil)
+			}
 		} else if e.Event_Id == mpv.EVENT_START_FILE {
 			ui.player.ReplaceInProgress = false
 			ui.startStopStatus.SetText("[::b]stmp: [green]playing " + ui.player.Queue[0].Title)
 			updateQueueList(ui.player, ui.queueList)
+		} else if e.Event_Id == mpv.EVENT_IDLE || e.Event_Id == mpv.EVENT_NONE {
+			continue
+		} else if e.Event_Id != mpv.EVENT_PROPERTY_CHANGE {
+			var qi QueueItem
+			if len(ui.player.Queue) > 0 {
+				qi = ui.player.Queue[0]
+			}
+			ui.logList.AddItem(fmt.Sprintf("Player event %s - %s", e.Event_Id.String(), qi.Uri), "", 0, nil)
 		}
 
-		// TODO how to handle mpv errors here?
-		position, _ := ui.player.Instance.GetProperty("time-pos", mpv.FORMAT_DOUBLE)
+		position, err := ui.player.Instance.GetProperty("time-pos", mpv.FORMAT_DOUBLE)
+		if err != nil {
+			ui.logList.AddItem(fmt.Sprintf("handleMoveEvents (%s): GetProperty %s -- %s", e.Event_Id.String(), "time-pos", err.Error()), "", 0, nil)
+		}
 		// TODO only update these as needed
-		duration, _ := ui.player.Instance.GetProperty("duration", mpv.FORMAT_DOUBLE)
-		volume, _ := ui.player.Instance.GetProperty("volume", mpv.FORMAT_INT64)
+		duration, err := ui.player.Instance.GetProperty("duration", mpv.FORMAT_DOUBLE)
+		if err != nil {
+			ui.logList.AddItem(fmt.Sprintf("handleMoveEvents (%s): GetProperty %s -- %s", e.Event_Id.String(), "duration", err.Error()), "", 0, nil)
+		}
+		volume, err := ui.player.Instance.GetProperty("volume", mpv.FORMAT_INT64)
+		if err != nil {
+			ui.logList.AddItem(fmt.Sprintf("handleMoveEvents (%s): GetProperty %s -- %s", e.Event_Id.String(), "volume", err.Error()), "", 0, nil)
+		}
 
 		if position == nil {
 			position = 0.0
@@ -604,7 +754,7 @@ func iSecondsToMinAndSec(seconds int) (int, int) {
 	return minutes, remainingSeconds
 }
 
-/// if the first argument isn't empty, return it, otherwise return the second
+// if the first argument isn't empty, return it, otherwise return the second
 func stringOr(firstChoice string, secondChoice string) string {
 	if firstChoice != "" {
 		return firstChoice
@@ -612,7 +762,7 @@ func stringOr(firstChoice string, secondChoice string) string {
 	return secondChoice
 }
 
-/// Return the title if present, otherwise fallback to the file path
+// Return the title if present, otherwise fallback to the file path
 func (e SubsonicEntity) getSongTitle() string {
 	if e.Title != "" {
 		return e.Title

--- a/gui.go
+++ b/gui.go
@@ -326,7 +326,7 @@ func (ui *Ui) makeEntityHandler(directoryId string) func() {
 	}
 }
 
-func createUi(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *SubsonicConnection) *Ui {
+func createUi(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *SubsonicConnection, player *Player) *Ui {
 	app := tview.NewApplication()
 	pages := tview.NewPages()
 	// list of entities
@@ -356,7 +356,6 @@ func createUi(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connectio
 		SetLabel("Playlist name:").
 		SetFieldWidth(50)
 	logs := tview.NewList().ShowSecondaryText(false)
-	player, err := InitPlayer()
 	var currentDirectory *SubsonicDirectory
 	var artistIdList []string
 
@@ -378,11 +377,6 @@ func createUi(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connectio
 		playlists:         *playlists,
 		connection:        connection,
 		player:            player,
-	}
-
-	if err != nil {
-		app.Stop()
-		fmt.Println("Unable to initialize mpv. Is mpv installed?")
 	}
 
 	go func() {
@@ -624,8 +618,8 @@ func (ui *Ui) createLogPage(titleFlex *tview.Flex) *tview.Flex {
 	return logFlex
 }
 
-func InitGui(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *SubsonicConnection) *Ui {
-	ui := createUi(indexes, playlists, connection)
+func InitGui(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *SubsonicConnection, player *Player) *Ui {
+	ui := createUi(indexes, playlists, connection, player)
 
 	// create components shared by pages
 

--- a/mpris2.go
+++ b/mpris2.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/godbus/dbus/v5/prop"
+)
+
+type MprisPlayer struct {
+	conn   *dbus.Conn
+	player *Player
+	logger Logger
+}
+
+// Mandatory functions
+func (mpp MprisPlayer) Stop() {
+	if err := mpp.player.Stop(); err != nil {
+		mpp.logger.Printf(err.Error())
+	}
+}
+func (mpp MprisPlayer) Next() {
+	mpp.player.PlayNextTrack()
+}
+func (mpp MprisPlayer) Pause() {
+	psd, err := mpp.player.IsPaused()
+	if err != nil {
+		mpp.logger.Printf(err.Error())
+		return
+	}
+	if !psd {
+		if _, err = mpp.player.Pause(); err != nil {
+			mpp.logger.Printf(err.Error())
+		}
+	}
+}
+func (mpp MprisPlayer) Play() {
+	psd, err := mpp.player.IsPaused()
+	if err != nil {
+		mpp.logger.Printf(err.Error())
+		return
+	}
+	if psd {
+		if _, err = mpp.player.Pause(); err != nil {
+			mpp.logger.Printf(err.Error())
+		}
+	}
+}
+func (mpp MprisPlayer) PlayPause() {
+	mpp.player.Pause()
+}
+func (mpp MprisPlayer) OpenUri(string) {
+	// TODO not implemented
+}
+func (mpp MprisPlayer) Previous() {
+	// TODO not implemented
+}
+func (mpp MprisPlayer) Seek(int) {
+	// TODO not implemented
+}
+func (mpp MprisPlayer) Seeked(int) {
+	// TODO not implemented
+}
+func (mpp MprisPlayer) SetPosition(string, int) {
+	// TODO not implemented
+}
+
+func RegisterPlayer(p *Player, l Logger) (MprisPlayer, error) {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		return MprisPlayer{}, err
+	}
+	parts := []string{"", "org", "mpris", "MediaPlayer2", "Player"}
+	path := strings.Join(parts, "/")
+	name := strings.Join(parts[1:], ".")
+	l.Printf("exporting %s %s\n", path, name)
+	mpp := MprisPlayer{
+		conn:   conn,
+		player: p,
+		logger: l,
+	}
+	err = conn.ExportAll(mpp, "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player")
+	if err != nil {
+		return MprisPlayer{}, err
+	}
+	/*
+		func (mpp MprisPlayer) Metadata() string {
+			if len(mpp.player.Queue) == 0 {
+				return ""
+			}
+			playing := mpp.player.Queue[0]
+			return fmt.Sprintf("%s - %s", playing.Artist, playing.Title)
+		}
+		Shuffle true/false
+		LoopStatus "Noneon, "Track", "Playlist"
+		Position time_in_us
+		MaximumRate, Rate, MinimumRate (float 0-1, x speed)
+	*/
+	metadata := map[string]interface{}{
+		"mpris:trackid":     "",
+		"mpris:length":      int64(0),
+		"xesam:album":       "",
+		"xesam:albumArtist": "",
+		"xesam:artist":      []string{},
+		"xesam:composer":    []string{},
+		"xesam:genre":       []string{},
+		"xesam:title":       "",
+		"xesam:trackNumber": int(0),
+	}
+
+	propSpec := map[string]map[string]*prop.Prop{
+		"org.mpris.MediaPlayer2.Player": {
+			"CanControl":    {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
+			"CanGoNext":     {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
+			"CanPause":      {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
+			"CanPlay":       {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
+			"CanSeek":       {Value: false, Writable: false, Emit: prop.EmitFalse, Callback: nil},
+			"CanGoPrevious": {Value: false, Writable: false, Emit: prop.EmitFalse, Callback: nil},
+			"Metadata":      {Value: metadata, Writable: false, Emit: prop.EmitTrue, Callback: nil},
+			"Volume": {Value: float64(0.0), Writable: true, Emit: prop.EmitTrue, Callback: func(c *prop.Change) *dbus.Error {
+				oldVolume, err := mpp.player.Volume()
+				if err != nil {
+					mpp.logger.Printf(err.Error())
+					return nil
+				}
+				fvol := c.Value.(float64)
+				if fvol < 0 {
+					mpp.player.AdjustVolume(-oldVolume)
+					return nil
+				}
+				vol := int64(fvol * 100)
+				volDiff := vol - oldVolume
+				mpp.player.AdjustVolume(volDiff)
+				return nil
+			},
+			},
+			"PlaybackStatus": {Value: "", Writable: false, Emit: prop.EmitFalse, Callback: nil},
+		},
+	}
+	props, err := prop.Export(conn, "/org/mpris/MediaPlayer2", propSpec)
+	if err != nil {
+		return MprisPlayer{}, err
+	}
+	n := &introspect.Node{
+		Name: "/org/mpris/MediaPlayer2",
+		Interfaces: []introspect.Interface{
+			introspect.IntrospectData,
+			prop.IntrospectData,
+			{
+				Name:       "org.mpris.MediaPlayer2.Player",
+				Methods:    introspect.Methods(mpp),
+				Properties: props.Introspection("org.mpris.MediaPlayer2.Player"),
+			},
+		},
+	}
+	err = conn.Export(introspect.NewIntrospectable(n), "/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Introspectable")
+	if err != nil {
+		return MprisPlayer{}, err
+	}
+	reply, err := conn.RequestName(name, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		return MprisPlayer{}, err
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		return MprisPlayer{}, fmt.Errorf("name already owned")
+	}
+	return mpp, nil
+}
+
+func (m MprisPlayer) Close() {
+	m.conn.Close()
+}

--- a/player.go
+++ b/player.go
@@ -136,6 +136,14 @@ func (p *Player) AdjustVolume(increment int64) error {
 	return p.Instance.SetProperty("volume", mpv.FORMAT_INT64, nevVolume)
 }
 
+func (p *Player) Volume() (int64, error) {
+	volume, err := p.Instance.GetProperty("volume", mpv.FORMAT_INT64)
+	if err != nil {
+		return -1, err
+	}
+	return volume.(int64), nil
+}
+
 func (p *Player) Seek(increment int) error {
 	return p.Instance.Command([]string{"seek", strconv.Itoa(increment)})
 }

--- a/player.go
+++ b/player.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"github.com/wildeyedskies/go-mpv/mpv"
+	"strconv"
 )
 
 const (
-	PlayerStopped = 0
-	PlayerPlaying = 1
-	PlayerPaused  = 2
+	PlayerStopped = iota
+	PlayerPlaying
+	PlayerPaused
+	PlayerError
 )
 
 type QueueItem struct {
@@ -48,62 +50,79 @@ func InitPlayer() (*Player, error) {
 		return nil, err
 	}
 
-	return &Player{mpvInstance, eventListener(mpvInstance), nil, false}, nil
+	return &Player{mpvInstance, eventListener(mpvInstance), make([]QueueItem, 0), false}, nil
 }
 
-func (p *Player) PlayNextTrack() {
+func (p *Player) PlayNextTrack() error {
 	if len(p.Queue) > 0 {
-		p.Instance.Command([]string{"loadfile", p.Queue[0].Uri})
+		return p.Instance.Command([]string{"loadfile", p.Queue[0].Uri})
 	}
+	return nil
 }
 
-func (p *Player) Play(uri string, title string, artist string, duration int) {
-	p.Queue = []QueueItem{QueueItem{uri, title, artist, duration}}
+func (p *Player) Play(uri string, title string, artist string, duration int) error {
+	p.Queue = []QueueItem{{uri, title, artist, duration}}
 	p.ReplaceInProgress = true
-	p.Instance.Command([]string{"loadfile", uri})
+	if ip, e := p.IsPaused(); ip && e == nil {
+		p.Pause()
+	}
+	return p.Instance.Command([]string{"loadfile", uri})
 }
 
-func (p *Player) Stop() {
-	p.Instance.Command([]string{"stop"})
+func (p *Player) Stop() error {
+	return p.Instance.Command([]string{"stop"})
 }
 
-func (p *Player) IsSongLoaded() bool {
-	idle, _ := p.Instance.GetProperty("idle-active", mpv.FORMAT_FLAG)
-	return !idle.(bool)
+func (p *Player) IsSongLoaded() (bool, error) {
+	idle, err := p.Instance.GetProperty("idle-active", mpv.FORMAT_FLAG)
+	return !idle.(bool), err
 }
 
-func (p *Player) IsPaused() bool {
-	pause, _ := p.Instance.GetProperty("pause", mpv.FORMAT_FLAG)
-	return pause.(bool)
+func (p *Player) IsPaused() (bool, error) {
+	pause, err := p.Instance.GetProperty("pause", mpv.FORMAT_FLAG)
+	return pause.(bool), err
 }
 
-func (p *Player) Pause() int {
-	loaded := p.IsSongLoaded()
-	pause := p.IsPaused()
+// Pause toggles playing music
+// If a song is playing, it is paused. If a song is paused, playing resumes. The
+// state after the toggle is returned, or an error.
+func (p *Player) Pause() (int, error) {
+	loaded, err := p.IsSongLoaded()
+	if err != nil {
+		return PlayerError, err
+	}
+	pause, err := p.IsPaused()
+	if err != nil {
+		return PlayerError, err
+	}
 
 	if loaded {
-		if pause {
-			p.Instance.SetProperty("pause", mpv.FORMAT_FLAG, false)
-			return PlayerPlaying
-		} else {
-			p.Instance.SetProperty("pause", mpv.FORMAT_FLAG, true)
-			return PlayerPaused
+		err := p.Instance.Command([]string{"cycle", "pause"})
+		if err != nil {
+			return PlayerError, err
 		}
+		if pause {
+			return PlayerPlaying, nil
+		}
+		return PlayerPaused, nil
 	} else {
 		if len(p.Queue) != 0 {
-			p.Instance.Command([]string{"loadfile", p.Queue[0].Uri})
-			return PlayerPlaying
+			err := p.Instance.Command([]string{"loadfile", p.Queue[0].Uri})
+			return PlayerPlaying, err
 		} else {
-			return PlayerStopped
+			return PlayerStopped, nil
 		}
 	}
 }
 
-func (p *Player) AdjustVolume(increment int64) {
-	volume, _ := p.Instance.GetProperty("volume", mpv.FORMAT_INT64)
+func (p *Player) AdjustVolume(increment int64) error {
+	volume, err := p.Instance.GetProperty("volume", mpv.FORMAT_INT64)
+	if err != nil {
+		return err
+	}
 
 	if volume == nil {
-		return
+		return nil
 	}
 
 	nevVolume := volume.(int64) + increment
@@ -114,5 +133,9 @@ func (p *Player) AdjustVolume(increment int64) {
 		nevVolume = 0
 	}
 
-	p.Instance.SetProperty("volume", mpv.FORMAT_INT64, nevVolume)
+	return p.Instance.SetProperty("volume", mpv.FORMAT_INT64, nevVolume)
+}
+
+func (p *Player) Seek(increment int) error {
+	return p.Instance.Command([]string{"seek", strconv.Itoa(increment)})
 }

--- a/stmp.go
+++ b/stmp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -37,6 +38,15 @@ func (l Logger) Printf(s string, as ...interface{}) {
 }
 
 func main() {
+	help := flag.Bool("help", false, "Print usage")
+	enableMpris := flag.Bool("mpris", false, "Enable MPRIS2")
+	flag.Parse()
+	if *help {
+		fmt.Printf("USAGE: %s <args>\n", os.Args[0])
+		flag.Usage()
+		os.Exit(0)
+	}
+
 	readConfig()
 
 	logger := Logger{make(chan string, 100)}
@@ -51,14 +61,30 @@ func main() {
 
 	indexResponse, err := connection.GetIndexes()
 	if err != nil {
-		fmt.Printf("Error fetching indexes from server: %s", err)
+		fmt.Printf("Error fetching indexes from server: %s\n", err)
 		os.Exit(1)
 	}
 	playlistResponse, err := connection.GetPlaylists()
 	if err != nil {
-		fmt.Printf("Error fetching indexes from server: %s", err)
+		fmt.Printf("Error fetching indexes from server: %s\n", err)
 		os.Exit(1)
 	}
 
-	InitGui(&indexResponse.Indexes.Index, &playlistResponse.Playlists.Playlists, connection)
+	player, err := InitPlayer()
+	if err != nil {
+		fmt.Println("Unable to initialize mpv. Is mpv installed?")
+		os.Exit(1)
+	}
+
+	if *enableMpris {
+		mpris, err := RegisterPlayer(player, logger)
+		if err != nil {
+			fmt.Printf("Unable to register MPRIS with DBUS: %s\n", err)
+			fmt.Println("Try running without MPRIS")
+			os.Exit(1)
+		}
+		defer mpris.Close()
+	}
+
+	InitGui(&indexResponse.Indexes.Index, &playlistResponse.Playlists.Playlists, connection, player)
 }


### PR DESCRIPTION
This patch fixes some bugs and adds a couple of features; it also changes the behavior of "add":

- Resume after pause was not working with Navidrome; pause simply stopped playback, and could not be resumed. Changing the command to "cycle pause" fixes this
- Because the code didn't tell the API to listen to changes, the play counter wasn't updated (again, with Navidrome)
- I added an ability to log and report errors as a new panel ('4'), to see what was going on and why things were failing.
- The currently selected card is now displayed in the center-top
- I added the ability to search the artists list, with '/ (enter search term)', 'n' (continue searching forward), and 'N' (continue searching backward)
- 'a' to add items to the queue now also advances the seleceted item by one; this allows adding multiple items by pressing 'a' repeatedly, rather than requiring the combination of 'a'+'down'
- Adds MPRIS2 support. Supports play/pause & volume, not much else in this version.