### PR TITLE
Addresses #16, sorting by track. The browser list is sorted:

### DIFF
--- a/api.go
+++ b/api.go
@@ -66,7 +66,7 @@ type SubsonicDirectory struct {
 	Id       string           `json:"id"`
 	Parent   string           `json:"parent"`
 	Name     string           `json:"name"`
-	Entities []SubsonicEntity `json:"child"`
+	Entities SubsonicEntities `json:"child"`
 }
 
 type SubsonicEntity struct {
@@ -79,6 +79,29 @@ type SubsonicEntity struct {
 	Track       int    `json:"track"`
 	DiskNumber  int    `json:"diskNumber"`
 	Path        string `json:"path"`
+}
+
+// SubsonicEntities is a sortable list of entities.
+// Directories are first, then in alphabelical order. Entities are sorted by
+// track number, if they have track numbers; otherwise, they're sorted
+// alphabetically.
+type SubsonicEntities []SubsonicEntity
+
+func (s SubsonicEntities) Len() int      { return len(s) }
+func (s SubsonicEntities) Swap(i, j int) { s[j], s[i] = s[i], s[j] }
+func (s SubsonicEntities) Less(i, j int) bool {
+	// Directories are before tracks, alphabetically
+	if s[i].IsDirectory {
+		if s[j].IsDirectory {
+			return s[i].Title < s[j].Title
+		}
+		return true
+	}
+	// If the tracks are the same, sort alphabetically
+	if s[i].Track == s[j].Track {
+		return s[i].Title < s[j].Title
+	}
+	return s[i].Track < s[j].Track
 }
 
 type SubsonicIndexes struct {
@@ -98,7 +121,7 @@ type SubsonicPlaylist struct {
 	Id        SubsonicId       `json:"id"`
 	Name      string           `json:"name"`
 	SongCount int              `json:"songCount"`
-	Entries   []SubsonicEntity `json:"entry"`
+	Entries   SubsonicEntities `json:"entry"`
 }
 
 type SubsonicResponse struct {

--- a/gui.go
+++ b/gui.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
@@ -35,6 +36,7 @@ type Ui struct {
 
 func (ui *Ui) handleEntitySelected(directoryId string) {
 	response, err := ui.connection.GetMusicDirectory(directoryId)
+	sort.Sort(response.Directory.Entities)
 	if err != nil {
 		ui.logList.AddItem(fmt.Sprintf("handleEntitySelected: GetMusicDirectory %s -- %s", directoryId, err.Error()), "", 0, nil)
 	}
@@ -212,6 +214,7 @@ func (ui *Ui) addDirectoryToQueue(entity *SubsonicEntity) {
 		return
 	}
 
+	sort.Sort(response.Directory.Entities)
 	for _, e := range response.Directory.Entities {
 		if e.IsDirectory {
 			ui.addDirectoryToQueue(&e)


### PR DESCRIPTION
1. Directories first, and in alphabetical order
2. Track number
3. Alphabetical track title

If two tracks have the same track number, then they are sorted alphabetically. If track numbers are not specified, they will be 0, which means they'll all have the same track number and therefore sorted alphabetically.

I think this doesn't affect playlists (which it shouldn't because those are ordered by the user), but that's untested.