### PR TITLE
Makes the code thread-safe.

### DIFF
--- a/stmp.go
+++ b/stmp.go
@@ -86,5 +86,5 @@ func main() {
 		defer mpris.Close()
 	}
 
-	InitGui(&indexResponse.Indexes.Index, &playlistResponse.Playlists.Playlists, connection, player)
+	InitGui(&indexResponse.Indexes.Index, &playlistResponse.Playlists.Playlists, connection, player, logger)
 }


### PR DESCRIPTION
So, this adds no features, but it does ensure thread safety of the code base.  It fixes #25

There are two areas this affects:

1. tview, like most UI toolkits, has constraints about modifying view elements.  This is [documented by tview](https://github.com/rivo/tview/wiki/Concurrency). I've wrapped these as best I could.
2. The code is cavelier about sharing data between goroutines. There wasn't too much of this; it mainly affected the array `Player.Queue`, which was modified and read in different goroutines. This code adds control via an `RWMutex`. I considered, and rejected, accessors; there few enough similar uses to seem worth it.

It's probably rare for any users to hit any of these. I put this in while trying to debug a different issue, which it didn't solve... but this change makes the code safer, so...