### PR TITLE
Fixes #33

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,32 @@
 module github.com/wildeyedskies/stmp
 
-go 1.15
+go 1.19
 
 require (
 	github.com/gdamore/tcell/v2 v2.1.0
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/rivo/tview v0.0.0-20201204190810-5406288b8e4e
 	github.com/spf13/viper v1.7.1
-	github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756 // indirect
+	github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756
+)
+
+require (
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20201017003518-b09fb700fbb7 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756 h1:lB4C5hJIjUpbfaSuMT/cl/+ZqCxyqTzJeI0ZvFItwWg=
 github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756/go.mod h1:RhhuJvJB4LWzwW2ls4J+4II6vFVd8WCiw6iKnrz2W68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/yourok/go-mpv v0.0.0-20160721123233-ecdfd901e332 h1:vK2mog8IZi/ml5Ej6IDk9X/N20Gzg6gbXYt8+7OWvcE=
-github.com/yourok/go-mpv v0.0.0-20160721123233-ecdfd901e332/go.mod h1:G4jkA/q5AjKcmEdS9VoZoK+gjB8oF3hu6FX8V3I1rxk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/gui.go
+++ b/gui.go
@@ -36,16 +36,16 @@ type Ui struct {
 
 func (ui *Ui) handleEntitySelected(directoryId string) {
 	response, err := ui.connection.GetMusicDirectory(directoryId)
-	sort.Sort(response.Directory.Entities)
 	if err != nil {
 		ui.logList.AddItem(fmt.Sprintf("handleEntitySelected: GetMusicDirectory %s -- %s", directoryId, err.Error()), "", 0, nil)
+		return
 	}
+	sort.Sort(response.Directory.Entities)
 
 	ui.currentDirectory = &response.Directory
 	ui.entityList.Clear()
 	if response.Directory.Parent != "" {
-		ui.entityList.AddItem(tview.Escape("[..]"), "", 0,
-			ui.makeEntityHandler(response.Directory.Parent))
+		ui.entityList.AddItem(tview.Escape("[..]"), "", 0, ui.makeEntityHandler(response.Directory.Parent))
 	}
 
 	for _, entity := range response.Directory.Entities {
@@ -56,9 +56,7 @@ func (ui *Ui) handleEntitySelected(directoryId string) {
 			handler = ui.makeEntityHandler(entity.Id)
 		} else {
 			title = entity.getSongTitle()
-			handler = makeSongHandler(ui.connection.GetPlayUrl(&entity),
-				title, stringOr(entity.Artist, response.Directory.Name),
-				entity.Duration, ui.player, ui.queueList)
+			handler = makeSongHandler(ui.connection.GetPlayUrl(&entity), title, stringOr(entity.Artist, response.Directory.Name), entity.Duration, ui.player, ui.queueList)
 		}
 
 		ui.entityList.AddItem(title, "", 0, handler)


### PR DESCRIPTION
Update go to 1.19, to get context; add timeout to getResponse to prevent hangs. Fixes #33.

Calls to the server via `SubSonicConnection.getResponse()` can hang indefinitely. Because UI events can call `getResponse`, if the call hangs, so does the UI.

This change adds a timeout context to `getResponse`, allowing the call to time out and return, and preventing UI hangs. While it may not resolve the server call issue, it does allow users to switch to the log panel and possibly see errors, and also allows users to cleanly exit the program (with `q`).