### PR TITLE
Adds "Refresh" to both the artist list, and for individual artists

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ host = 'https://your-subsonic-host.tld'
 * / - Search artists
 * n - Continue search forward
 * N - Continue search backwards
+* r - refresh the list (if in artist directory, only refreshes that artist)

--- a/api.go
+++ b/api.go
@@ -230,7 +230,6 @@ func (connection *SubsonicConnection) CreatePlaylist(name string) (*SubsonicResp
 }
 
 func (connection *SubsonicConnection) getResponse(caller, requestUrl string) (*SubsonicResponse, error) {
-	connection.Logger.Printf("%s %s", caller, requestUrl)
 	res, err := http.Get(requestUrl)
 
 	if err != nil {
@@ -261,7 +260,6 @@ func (connection *SubsonicConnection) DeletePlaylist(id string) error {
 	query := defaultQuery(connection)
 	query.Set("id", id)
 	requestUrl := connection.Host + "/rest/deletePlaylist" + "?" + query.Encode()
-	connection.Logger.Printf("DeletePlaylist %s", requestUrl)
 	_, err := http.Get(requestUrl)
 	return err
 }
@@ -271,7 +269,6 @@ func (connection *SubsonicConnection) AddSongToPlaylist(playlistId string, songI
 	query.Set("playlistId", playlistId)
 	query.Set("songIdToAdd", songId)
 	requestUrl := connection.Host + "/rest/updatePlaylist" + "?" + query.Encode()
-	connection.Logger.Printf("AddSongToPlaylist %s", requestUrl)
 	_, err := http.Get(requestUrl)
 	return err
 }
@@ -281,7 +278,6 @@ func (connection *SubsonicConnection) RemoveSongFromPlaylist(playlistId string, 
 	query.Set("playlistId", playlistId)
 	query.Set("songIndexToRemove", strconv.Itoa(songIndex))
 	requestUrl := connection.Host + "/rest/updatePlaylist" + "?" + query.Encode()
-	connection.Logger.Printf("RemoveSongFromPlaylist %s", requestUrl)
 	_, err := http.Get(requestUrl)
 	return err
 }

--- a/gui.go
+++ b/gui.go
@@ -452,7 +452,7 @@ func (ui *Ui) createBrowserPage(titleFlex *tview.Flex, indexes *[]SubsonicIndex)
 			// REFRESH artists
 			indexResponse, err := ui.connection.GetIndexes()
 			if err != nil {
-				ui.logger.Printf("Error fetching indexes from server: %s\n", err)
+				ui.connection.Logger.Printf("Error fetching indexes from server: %s\n", err)
 				return event
 			}
 			ui.artistList.Clear()

--- a/gui.go
+++ b/gui.go
@@ -456,6 +456,7 @@ func (ui *Ui) createBrowserPage(titleFlex *tview.Flex, indexes *[]SubsonicIndex)
 				return event
 			}
 			ui.artistList.Clear()
+			ui.connection.directoryCache = make(map[string]SubsonicResponse)
 			for _, index := range indexResponse.Indexes.Index {
 				for _, artist := range index.Artists {
 					ui.artistList.AddItem(artist.Name, "", 0, nil)

--- a/gui.go
+++ b/gui.go
@@ -792,12 +792,6 @@ func (ui *Ui) handleMpvEvents() {
 			updateQueueList(ui.player, ui.queueList)
 		} else if e.Event_Id == mpv.EVENT_IDLE || e.Event_Id == mpv.EVENT_NONE {
 			continue
-		} else if e.Event_Id != mpv.EVENT_PROPERTY_CHANGE {
-			var qi QueueItem
-			if len(ui.player.Queue) > 0 {
-				qi = ui.player.Queue[0]
-			}
-			ui.connection.Logger.Printf("Player event %s - %s", e.Event_Id.String(), qi.Uri)
 		}
 
 		position, err := ui.player.Instance.GetProperty("time-pos", mpv.FORMAT_DOUBLE)

--- a/mpris2.go
+++ b/mpris2.go
@@ -73,9 +73,7 @@ func RegisterPlayer(p *Player, l Logger) (MprisPlayer, error) {
 		return MprisPlayer{}, err
 	}
 	parts := []string{"", "org", "mpris", "MediaPlayer2", "Player"}
-	path := strings.Join(parts, "/")
 	name := strings.Join(parts[1:], ".")
-	l.Printf("exporting %s %s\n", path, name)
 	mpp := MprisPlayer{
 		conn:   conn,
 		player: p,


### PR DESCRIPTION
The agressive caching means that users will never see changes to the music list on the server unless they exit and restart. This patch allows the client to get new content from the server by adding "Refresh" commands: 'r'

If in the artist list, it refreshes the entire artist list. If an artist is selected, then 'r' refreshes only that artist info.

There's one other small, unrelated change in this patch: there are several places in stmp code where function signatures include passing data that's never used. It's probably just cruft; `createUI` had one of them. I'm marking them as I find them for separate "clean-up" patches, so this is one of those. 

**Edit** the additional two commits make sure that the artists' directories are refreshed when the artist list is, and remove some verbose (non-error) logging. I didn't mean for the second commit to get sucked in, but 🤷🏻‍♂️ 