### PR TITLE
Scrobbling Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ or the directory in which the executible is placed.
 [auth]
 username = 'admin'
 password = 'password'
-plaintext = true # Use 'legacy' unsalted password auth. (default: false)
+plaintext = true  # Use 'legacy' unsalted password auth. (default: false)
 
 [server]
 host = 'https://your-subsonic-host.tld'
+scrobble = true   # Use Subsonic scrobbling for last.fm/ListenBrainz (default: false)
 ```
 
 ## Usage

--- a/api.go
+++ b/api.go
@@ -19,6 +19,7 @@ type SubsonicConnection struct {
 	Password       string
 	Host           string
 	PlaintextAuth  bool
+	Scrobble       bool
 	Logger         Logger
 	directoryCache map[string]SubsonicResponse
 }
@@ -209,6 +210,22 @@ func (connection *SubsonicConnection) GetRandomSongs() (*SubsonicResponse, error
 	requestUrl := connection.Host + "/rest/getRandomSongs" + "?" + query.Encode()
 	resp, err := connection.getResponse("GetRandomSongs", requestUrl)
 	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+func (connection *SubsonicConnection) ScrobbleSubmission(id string, isSubmission bool) (*SubsonicResponse, error) {
+	query := defaultQuery(connection)
+	query.Set("id", id)
+
+	// optional field, false for "now playing", true for "submission"
+	query.Set("submission", strconv.FormatBool(isSubmission))
+
+	requestUrl := connection.Host + "/rest/scrobble" + "?" + query.Encode()
+	resp, err := connection.getResponse("ScrobbleSubmission", requestUrl)
+	if err != nil {
+		connection.Logger.Printf("ScrobbleSubmission error: %v", err)
 		return resp, err
 	}
 	return resp, nil

--- a/gui.go
+++ b/gui.go
@@ -919,6 +919,13 @@ func (ui *Ui) handleMpvEvents() {
 			ui.player.ReplaceInProgress = false
 			ui.startStopStatus.SetText("[::b]stmp: [green]playing " + ui.player.Queue[0].Title)
 			updateQueueList(ui.player, ui.queueList, ui.starIdList)
+
+			if ui.connection.Scrobble {
+				// scrobble "now playing" event
+				ui.connection.ScrobbleSubmission(ui.player.Queue[0].Id, false)
+				// scrobble "submission" event
+				ui.connection.ScrobbleSubmission(ui.player.Queue[0].Id, true)
+			}
 		} else if e.Event_Id == mpv.EVENT_IDLE || e.Event_Id == mpv.EVENT_NONE {
 			continue
 		}

--- a/gui.go
+++ b/gui.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -33,6 +34,7 @@ type Ui struct {
 	playlists         []SubsonicPlaylist
 	connection        *SubsonicConnection
 	player            *Player
+	scrobbleTimer     *time.Timer
 }
 
 func (ui *Ui) handleEntitySelected(directoryId string) {
@@ -465,6 +467,12 @@ func createUi(_ *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *Sub
 	// Stores the song IDs
 	var starIdList = map[string]struct{}{}
 
+	// create reused timer to scrobble after delay
+	scrobbleTimer := time.NewTimer(0)
+	if !scrobbleTimer.Stop() {
+		<-scrobbleTimer.C
+	}
+
 	ui := Ui{
 		app:               app,
 		pages:             pages,
@@ -484,6 +492,7 @@ func createUi(_ *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *Sub
 		playlists:         *playlists,
 		connection:        connection,
 		player:            player,
+		scrobbleTimer:     scrobbleTimer,
 	}
 
 	ui.addStarredToList()
@@ -499,6 +508,17 @@ func createUi(_ *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection *Sub
 						ui.logList.RemoveItem(0)
 					}
 				})
+
+			case <-scrobbleTimer.C:
+				// scrobble submission delay elapsed
+				paused, err := ui.player.IsPaused()
+				connection.Logger.Printf("scrobbler event: paused %v, err %v, qlen %d", paused, err, len(ui.player.Queue))
+				isPlaying := err == nil && !paused
+				if len(ui.player.Queue) > 0 && isPlaying {
+					// it's still playing, submit it
+					currentSong := ui.player.Queue[0]
+					ui.connection.ScrobbleSubmission(currentSong.Id, true)
+				}
 			}
 		}
 	}()
@@ -917,14 +937,34 @@ func (ui *Ui) handleMpvEvents() {
 			}
 		} else if e.Event_Id == mpv.EVENT_START_FILE {
 			ui.player.ReplaceInProgress = false
-			ui.startStopStatus.SetText("[::b]stmp: [green]playing " + ui.player.Queue[0].Title)
 			updateQueueList(ui.player, ui.queueList, ui.starIdList)
 
-			if ui.connection.Scrobble {
-				// scrobble "now playing" event
-				ui.connection.ScrobbleSubmission(ui.player.Queue[0].Id, false)
-				// scrobble "submission" event
-				ui.connection.ScrobbleSubmission(ui.player.Queue[0].Id, true)
+			if len(ui.player.Queue) > 0 {
+				currentSong := ui.player.Queue[0]
+				ui.startStopStatus.SetText("[::b]stmp: [green]playing " + currentSong.Title)
+
+				if ui.connection.Scrobble {
+					// scrobble "now playing" event
+					ui.connection.ScrobbleSubmission(currentSong.Id, false)
+
+					// scrobble "submission" after song has been playing a bit
+					// see: https://www.last.fm/api/scrobbling
+					// A track should only be scrobbled when the following conditions have been met:
+					// The track must be longer than 30 seconds. And the track has been played for
+					// at least half its duration, or for 4 minutes (whichever occurs earlier.)
+					if currentSong.Duration > 30 {
+						scrobbleDelay := currentSong.Duration / 2
+						if scrobbleDelay > 240 {
+							scrobbleDelay = 240
+						}
+						scrobbleDuration := time.Duration(scrobbleDelay) * time.Second
+
+						ui.scrobbleTimer.Reset(scrobbleDuration)
+						ui.connection.Logger.Printf("scrobbler: timer started, %v", scrobbleDuration)
+					} else {
+						ui.connection.Logger.Printf("scrobbler: track too short")
+					}
+				}
 			}
 		} else if e.Event_Id == mpv.EVENT_IDLE || e.Event_Id == mpv.EVENT_NONE {
 			continue

--- a/stmp.go
+++ b/stmp.go
@@ -56,6 +56,7 @@ func main() {
 		Password:       viper.GetString("auth.password"),
 		Host:           viper.GetString("server.host"),
 		PlaintextAuth:  viper.GetBool("auth.plaintext"),
+		Scrobble:       viper.GetBool("server.scrobble"),
 		Logger:         logger,
 		directoryCache: make(map[string]SubsonicResponse),
 	}


### PR DESCRIPTION
I started to implement support for the `/rest/scrobble` endpoint (see <http://www.subsonic.org/pages/api.jsp#scrobble>). 
Using that you can tell the Subsonic server to submit tracks to a server-side configured LastFM/ListenBrainz/etc. account.

So far I've been testing it with [navidrome](https://github.com/navidrome/navidrome) which submits to [musicbanana](https://github.com/jlieth/musicbanana) and it's working fine.

I would appreciate feedback. Otherwise my remaining TODO list for this PR is currently:

- figure out how to handle submission properly (currently the "now playing" and "submission" events are both sent at the start of a song; I think submission should be delayed though by `min(240, song_duration_seconds/2)` as usual) **-- edit: done**
- test it with gonic

PS: My [dev branch](https://github.com/spezifisch/stmp/tree/dev) has some other bugfixes as well for which I haven't gotten around yet to create PRs.