### PR TITLE
README: Fixed typo, deadlink, and added macOS path options for MacPorts Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,23 @@ A terminal client for *sonic music servers. Inspired by ncmpcpp.
 Go build dependencies
 
 * [tview](https://github.com/rivo/tview)
-* [go-mpv](https://github.com/yourok/go-mpv/mpv)
+* [go-mpv](https://github.com/YouROK/go-mpv)
 
-### OSX path setup
+### MacOS path setup
 
-On OSX if you installed mpv with brew you'll need to set the following paths
+#### Homebrew
+On MacOS, if you installed mpv with brew you'll need to set the following paths:
 
 ```
 export C_INCLUDE_PATH=/opt/homebrew/include:$C_INCLUDE_PATH
 export LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH
 ```
-
+#### Macports
+Alternatively, if you installed mpv with Macports, set these paths:
+```
+export C_INCLUDE_PATH=/opt/local/include:$C_INCLUDE_PATH
+export LIBRARY_PATH=/opt/local/lib:$LIBRARY_PATH
+```
 ## Compiling
 
 stmp should compile normally with `go build`. Cgo is needed for linking the
@@ -39,7 +45,7 @@ libmpv header.
 ## Configuration
 
 stmp looks for a config file called `stmp.toml` in either `$HOME/.config/stmp`
-or the directory in which the executible is placed.
+or the directory in which the executable is placed.
 
 ### Example configuration
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ On MacOS, if you installed mpv with brew you'll need to set the following paths:
 export C_INCLUDE_PATH=/opt/homebrew/include:$C_INCLUDE_PATH
 export LIBRARY_PATH=/opt/homebrew/lib:$LIBRARY_PATH
 ```
-#### Macports
-Alternatively, if you installed mpv with Macports, set these paths:
+#### MacPorts
+Alternatively, if you installed mpv with MacPorts, set these paths:
 ```
 export C_INCLUDE_PATH=/opt/local/include:$C_INCLUDE_PATH
 export LIBRARY_PATH=/opt/local/lib:$LIBRARY_PATH

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ export LIBRARY_PATH=/opt/local/lib:$LIBRARY_PATH
 
 stmp should compile normally with `go build`. Cgo is needed for linking the
 libmpv header.
-
+### Compiling on MacOS versions < 10.15 Catalina
+Mpv [no longer supports](https://github.com/mpv-player/mpv?tab=readme-ov-file#system-requirements) versions of MacOS older than 10.15. Users on such systems may want to build `mpv-0.36` or older, or use the [mpv-legacy](https://ports.macports.org/port/mpv-legacy/) MacPorts package.
 ## Configuration
 
 stmp looks for a config file called `stmp.toml` in either `$HOME/.config/stmp`

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Go build dependencies
 * [tview](https://github.com/rivo/tview)
 * [go-mpv](https://github.com/YouROK/go-mpv)
 
-### MacOS path setup
+### macOS path setup
 
 #### Homebrew
-On MacOS, if you installed mpv with brew you'll need to set the following paths:
+On macOS, if you installed mpv with brew you'll need to set the following paths:
 
 ```
 export C_INCLUDE_PATH=/opt/homebrew/include:$C_INCLUDE_PATH
@@ -41,8 +41,7 @@ export LIBRARY_PATH=/opt/local/lib:$LIBRARY_PATH
 
 stmp should compile normally with `go build`. Cgo is needed for linking the
 libmpv header.
-### Compiling on MacOS versions < 10.15 Catalina
-Mpv [no longer supports](https://github.com/mpv-player/mpv?tab=readme-ov-file#system-requirements) versions of MacOS older than 10.15. Users on such systems may want to build `mpv-0.36` or older, or use the [mpv-legacy](https://ports.macports.org/port/mpv-legacy/) MacPorts package.
+
 ## Configuration
 
 stmp looks for a config file called `stmp.toml` in either `$HOME/.config/stmp`


### PR DESCRIPTION
Hi,
Thanks for making this program,
I have some small additions to the README.md that could be worthwhile:
- fixed typo: 'executible' to 'executable'
- fixed outbound link to go-mpv repo
- changed OS X to macOS
  - in anticipation of potential detailed mac build notes, more on that below
- added path setup for MacPorts users, as per @dweymouth's [mac setup instructions for supersonic](https://github.com/dweymouth/supersonic#macports-setup), which have been mentioned a few times in some replies to various issues in this repo. The Homebrew path setup has since been included, but not the MacPorts one.

I didn't include it in this branch, but I made a [tentative second branch](https://github.com/samyarvahid/stmp/tree/detailed-mac-build-notes) that I could make another PR for, where I describe what needs to be done to get stmp working on macOS versions < 10.15, by building a version older than 0.37, or by using the macports `mpv-legacy` package.

Finally, I don't know if this is too out-of-scope, but as someone unfamiliar with go, it took me a little bit to realize that I needed to `go get` the go build dependencies. I could make that more clear with another couple lines in the readme, if it's of interest.

Thanks!