### PR TITLE
Integrate go-music-players/mpris library for MPRIS support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,29 @@ toolchain go1.22.2
 require (
 	github.com/gdamore/tcell/v2 v2.1.0
 	github.com/go-music-players/mpris v0.1.0
-	github.com/godbus/dbus/v5 v5.1.0
 	github.com/rivo/tview v0.0.0-20201204190810-5406288b8e4e
 	github.com/spf13/viper v1.7.1
 	github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756
+)
+
+require (
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20201017003518-b09fb700fbb7 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
 module github.com/wildeyedskies/stmp
 
-go 1.15
+go 1.22
+
+toolchain go1.22.2
 
 require (
 	github.com/gdamore/tcell/v2 v2.1.0
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/go-music-players/mpris v0.1.0
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/rivo/tview v0.0.0-20201204190810-5406288b8e4e
 	github.com/spf13/viper v1.7.1
-	github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756 // indirect
+	github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756
 )

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-music-players/mpris v0.1.0 h1:+4wyIL4HdfUX8crlYokWnLULKh9l2OSEoq7Z/3ArrR4=
+github.com/go-music-players/mpris v0.1.0/go.mod h1:CG1C0OaeTMiWs9EVHtHWBme1DjEXs/0O8lUqWDaGeRY=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -190,8 +192,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756 h1:lB4C5hJIjUpbfaSuMT/cl/+ZqCxyqTzJeI0ZvFItwWg=
 github.com/wildeyedskies/go-mpv v0.0.0-20221204042335-e8961dc66756/go.mod h1:RhhuJvJB4LWzwW2ls4J+4II6vFVd8WCiw6iKnrz2W68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
-github.com/yourok/go-mpv v0.0.0-20160721123233-ecdfd901e332 h1:vK2mog8IZi/ml5Ej6IDk9X/N20Gzg6gbXYt8+7OWvcE=
-github.com/yourok/go-mpv v0.0.0-20160721123233-ecdfd901e332/go.mod h1:G4jkA/q5AjKcmEdS9VoZoK+gjB8oF3hu6FX8V3I1rxk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/gui.go
+++ b/gui.go
@@ -422,7 +422,7 @@ func (ui *Ui) deletePlaylist(index int) {
 
 func makeSongHandler(id string, uri string, title string, artist string, duration int, player *Player, queueList *tview.List, starIdList map[string]struct{}) func() {
 	return func() {
-		player.Play(id, uri, title, artist, duration)
+		player.PlayTrack(id, uri, title, artist, duration)
 		updateQueueList(player, queueList, starIdList)
 	}
 }
@@ -844,9 +844,9 @@ func InitGui(indexes *[]SubsonicIndex, playlists *[]SubsonicPlaylist, connection
 			}
 			updateQueueList(ui.player, ui.queueList, ui.starIdList)
 		case keybind("playPause"):
-			status, err := ui.player.Pause()
+			status, err := ui.player.TogglePause()
 			if err != nil {
-				ui.connection.Logger.Printf("InitGui: Pause -- %s", err.Error())
+				ui.connection.Logger.Printf("InitGui: TogglePause -- %s", err.Error())
 				ui.startStopStatus.SetText("[::b]stmp: [red]error")
 				return nil
 			}

--- a/mpris2.go
+++ b/mpris2.go
@@ -1,172 +1,109 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/godbus/dbus/v5"
-	"github.com/godbus/dbus/v5/introspect"
-	"github.com/godbus/dbus/v5/prop"
+	"github.com/go-music-players/mpris"
+	"github.com/wildeyedskies/go-mpv/mpv"
 )
 
-type MprisPlayer struct {
-	conn   *dbus.Conn
-	player *Player
-	logger Logger
+// MPRIS Player interface implementation
+// Player directly implements mpris.Player interface
+
+// Play starts playback (implements mpris.Player)
+func (p *Player) Play() error {
+	isPaused, err := p.IsPaused()
+	if err != nil {
+		return err
+	}
+	if isPaused {
+		return p.Instance.SetProperty("pause", mpv.FORMAT_FLAG, false)
+	}
+	return nil
 }
 
-// Mandatory functions
-func (mpp MprisPlayer) Stop() {
-	if err := mpp.player.Stop(); err != nil {
-		mpp.logger.Printf(err.Error())
-	}
-}
-func (mpp MprisPlayer) Next() {
-	mpp.player.PlayNextTrack()
-}
-func (mpp MprisPlayer) Pause() {
-	psd, err := mpp.player.IsPaused()
+// Pause pauses playback (implements mpris.Player)
+func (p *Player) Pause() error {
+	isPaused, err := p.IsPaused()
 	if err != nil {
-		mpp.logger.Printf(err.Error())
-		return
+		return err
 	}
-	if !psd {
-		if _, err = mpp.player.Pause(); err != nil {
-			mpp.logger.Printf(err.Error())
-		}
+	if !isPaused {
+		return p.Instance.SetProperty("pause", mpv.FORMAT_FLAG, true)
 	}
-}
-func (mpp MprisPlayer) Play() {
-	psd, err := mpp.player.IsPaused()
-	if err != nil {
-		mpp.logger.Printf(err.Error())
-		return
-	}
-	if psd {
-		if _, err = mpp.player.Pause(); err != nil {
-			mpp.logger.Printf(err.Error())
-		}
-	}
-}
-func (mpp MprisPlayer) PlayPause() {
-	mpp.player.Pause()
-}
-func (mpp MprisPlayer) OpenUri(string) {
-	// TODO not implemented
-}
-func (mpp MprisPlayer) Previous() {
-	// TODO not implemented
-}
-func (mpp MprisPlayer) Seek(int) {
-	// TODO not implemented
-}
-func (mpp MprisPlayer) Seeked(int) {
-	// TODO not implemented
-}
-func (mpp MprisPlayer) SetPosition(string, int) {
-	// TODO not implemented
+	return nil
 }
 
-func RegisterPlayer(p *Player, l Logger) (MprisPlayer, error) {
-	conn, err := dbus.ConnectSessionBus()
-	if err != nil {
-		return MprisPlayer{}, err
-	}
-	parts := []string{"", "org", "mpris", "MediaPlayer2", "Player"}
-	name := strings.Join(parts[1:], ".")
-	mpp := MprisPlayer{
-		conn:   conn,
-		player: p,
-		logger: l,
-	}
-	err = conn.ExportAll(mpp, "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player")
-	if err != nil {
-		return MprisPlayer{}, err
-	}
-	/*
-		func (mpp MprisPlayer) Metadata() string {
-			if len(mpp.player.Queue) == 0 {
-				return ""
-			}
-			playing := mpp.player.Queue[0]
-			return fmt.Sprintf("%s - %s", playing.Artist, playing.Title)
-		}
-		Shuffle true/false
-		LoopStatus "Noneon, "Track", "Playlist"
-		Position time_in_us
-		MaximumRate, Rate, MinimumRate (float 0-1, x speed)
-	*/
-	metadata := map[string]interface{}{
-		"mpris:trackid":     "",
-		"mpris:length":      int64(0),
-		"xesam:album":       "",
-		"xesam:albumArtist": "",
-		"xesam:artist":      []string{},
-		"xesam:composer":    []string{},
-		"xesam:genre":       []string{},
-		"xesam:title":       "",
-		"xesam:trackNumber": int(0),
-	}
-
-	propSpec := map[string]map[string]*prop.Prop{
-		"org.mpris.MediaPlayer2.Player": {
-			"CanControl":    {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
-			"CanGoNext":     {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
-			"CanPause":      {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
-			"CanPlay":       {Value: true, Writable: false, Emit: prop.EmitFalse, Callback: nil},
-			"CanSeek":       {Value: false, Writable: false, Emit: prop.EmitFalse, Callback: nil},
-			"CanGoPrevious": {Value: false, Writable: false, Emit: prop.EmitFalse, Callback: nil},
-			"Metadata":      {Value: metadata, Writable: false, Emit: prop.EmitTrue, Callback: nil},
-			"Volume": {Value: float64(0.0), Writable: true, Emit: prop.EmitTrue, Callback: func(c *prop.Change) *dbus.Error {
-				oldVolume, err := mpp.player.Volume()
-				if err != nil {
-					mpp.logger.Printf(err.Error())
-					return nil
-				}
-				fvol := c.Value.(float64)
-				if fvol < 0 {
-					mpp.player.AdjustVolume(-oldVolume)
-					return nil
-				}
-				vol := int64(fvol * 100)
-				volDiff := vol - oldVolume
-				mpp.player.AdjustVolume(volDiff)
-				return nil
-			},
-			},
-			"PlaybackStatus": {Value: "", Writable: false, Emit: prop.EmitFalse, Callback: nil},
-		},
-	}
-	props, err := prop.Export(conn, "/org/mpris/MediaPlayer2", propSpec)
-	if err != nil {
-		return MprisPlayer{}, err
-	}
-	n := &introspect.Node{
-		Name: "/org/mpris/MediaPlayer2",
-		Interfaces: []introspect.Interface{
-			introspect.IntrospectData,
-			prop.IntrospectData,
-			{
-				Name:       "org.mpris.MediaPlayer2.Player",
-				Methods:    introspect.Methods(mpp),
-				Properties: props.Introspection("org.mpris.MediaPlayer2.Player"),
-			},
-		},
-	}
-	err = conn.Export(introspect.NewIntrospectable(n), "/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Introspectable")
-	if err != nil {
-		return MprisPlayer{}, err
-	}
-	reply, err := conn.RequestName(name, dbus.NameFlagDoNotQueue)
-	if err != nil {
-		return MprisPlayer{}, err
-	}
-	if reply != dbus.RequestNameReplyPrimaryOwner {
-		return MprisPlayer{}, fmt.Errorf("name already owned")
-	}
-	return mpp, nil
+// Next plays next track (implements mpris.Player)
+func (p *Player) Next() error {
+	p.PlayNextTrack()
+	return nil
 }
 
-func (m MprisPlayer) Close() {
-	m.conn.Close()
+// Previous plays previous track (implements mpris.Player)
+func (p *Player) Previous() error {
+	// stmp doesn't support previous
+	return nil
+}
+
+// GetPlaybackStatus returns current playback status (implements mpris.Player)
+func (p *Player) GetPlaybackStatus() (mpris.PlaybackStatus, error) {
+	state, err := p.State()
+	if err != nil {
+		return mpris.StatusStopped, err
+	}
+
+	switch state {
+	case PlayerPlaying:
+		return mpris.StatusPlaying, nil
+	case PlayerPaused:
+		return mpris.StatusPaused, nil
+	default:
+		return mpris.StatusStopped, nil
+	}
+}
+
+// GetMetadata returns track metadata (implements mpris.Player)
+func (p *Player) GetMetadata() (*mpris.Metadata, error) {
+	if len(p.Queue) == 0 {
+		return nil, nil
+	}
+
+	track := p.Queue[0]
+
+	metadata := &mpris.Metadata{
+		TrackID: track.Id,
+		Title:   track.Title,
+		Artist:  []string{track.Artist},
+	}
+
+	return metadata, nil
+}
+
+// CanPlay returns true if can play (implements mpris.Player)
+func (p *Player) CanPlay() bool {
+	return true
+}
+
+// CanPause returns true if can pause (implements mpris.Player)
+func (p *Player) CanPause() bool {
+	return true
+}
+
+// CanGoNext returns true if can go to next track (implements mpris.Player)
+func (p *Player) CanGoNext() bool {
+	return true
+}
+
+// CanGoPrevious returns true if can go to previous track (implements mpris.Player)
+func (p *Player) CanGoPrevious() bool {
+	return false // stmp doesn't support previous
+}
+
+// CanSeek returns true if can seek (implements mpris.Player)
+func (p *Player) CanSeek() bool {
+	return false // stmp doesn't support seeking via MPRIS
+}
+
+// CanControl returns true if player can be controlled (implements mpris.Player)
+func (p *Player) CanControl() bool {
+	return true
 }

--- a/player.go
+++ b/player.go
@@ -61,11 +61,11 @@ func (p *Player) PlayNextTrack() error {
 	return nil
 }
 
-func (p *Player) Play(id string, uri string, title string, artist string, duration int) error {
+func (p *Player) PlayTrack(id string, uri string, title string, artist string, duration int) error {
 	p.Queue = []QueueItem{{id, uri, title, artist, duration}}
 	p.ReplaceInProgress = true
 	if ip, e := p.IsPaused(); ip && e == nil {
-		p.Pause()
+		p.TogglePause()
 	}
 	return p.Instance.Command([]string{"loadfile", uri})
 }
@@ -84,10 +84,30 @@ func (p *Player) IsPaused() (bool, error) {
 	return pause.(bool), err
 }
 
-// Pause toggles playing music
+// State returns the current player state
+func (p *Player) State() (int, error) {
+	loaded, err := p.IsSongLoaded()
+	if err != nil {
+		return PlayerError, err
+	}
+	if !loaded {
+		return PlayerStopped, nil
+	}
+
+	paused, err := p.IsPaused()
+	if err != nil {
+		return PlayerError, err
+	}
+	if paused {
+		return PlayerPaused, nil
+	}
+	return PlayerPlaying, nil
+}
+
+// TogglePause toggles playing music
 // If a song is playing, it is paused. If a song is paused, playing resumes. The
 // state after the toggle is returned, or an error.
-func (p *Player) Pause() (int, error) {
+func (p *Player) TogglePause() (int, error) {
 	loaded, err := p.IsSongLoaded()
 	if err != nil {
 		return PlayerError, err

--- a/stmp.go
+++ b/stmp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-music-players/mpris"
 	"github.com/spf13/viper"
 )
 
@@ -108,7 +109,7 @@ func main() {
 	}
 
 	if *enableMpris {
-		mpris, err := RegisterPlayer(player, logger)
+		mpris, err := mpris.NewServer("stmp", player)
 		if err != nil {
 			fmt.Printf("Unable to register MPRIS with DBUS: %s\n", err)
 			fmt.Println("Try running without MPRIS")


### PR DESCRIPTION
Replace custom MPRIS with [go-music-players/mpris](https://github.com/go-music-players/mpris). Helps make  [MPRIS](https://specifications.freedesktop.org/mpris/latest/) behavior more consistent across Go music players.

